### PR TITLE
feat(models): add GPT-5 & GPT-5 Mini and set default model to gpt-5-mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to the "copilot-plus-plus" extension will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.17] - 2025-08-15
+### Added
+- Added GPT-5 (`gpt-5`) and GPT-5 Mini (`gpt-5-mini`) to the available language model selection
+- Updated webview model lists, UI components, and documentation to include GPT-5 and GPT-5 Mini
+
 ## [0.0.16] - 2025-07-07
 ### Added
 - Enhanced language model support with expanded model selection

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ You can customize the extension's behavior through the following settings:
   - **GPT-4o**: Most capable model, best for complex understanding
   - **GPT-4o-mini**: Faster variant with slightly reduced capabilities
   - **GPT-4.1**: Latest GPT-4 model with enhanced capabilities
+  - **GPT-5**: Next generation GPT model with larger context and improved capability
+  - **GPT-5 Mini**: Next generation mini model with improved efficiency and capabilities
   - **Claude 3.5 Sonnet**: Anthropic's most capable model with advanced reasoning
   - **Claude 4 Sonnet**: Latest Anthropic model with enhanced capabilities
   - **o1**: OpenAI o1 model, highest reasoning capabilities
@@ -149,6 +151,11 @@ You can customize the extension's behavior through the following settings:
    ```
 
 ## Release Notes
+
+### 0.0.17 (2025-08-15)
+- Added GPT-5 (`gpt-5`) and GPT-5 Mini (`gpt-5-mini`) to the available language model selection
+- Updated UI components and documentation to include GPT-5 and GPT-5 Mini (README, docs, and webview model lists)
+- Small fixes and consistency updates for model configuration across webviews
 
 ### 0.0.16 (2025-07-07)
 - Enhanced language model support with expanded model selection

--- a/docs/breaking-changes-analysis.md
+++ b/docs/breaking-changes-analysis.md
@@ -36,6 +36,8 @@ Select from various language models to perform the analysis:
 - GPT-4o
 - GPT-4.1
 - GPT-4o-mini
+- GPT-5 Mini
+- GPT-5
 - Claude 3.5 Sonnet
 - Claude 4 Sonnet 
 - o1

--- a/docs/commit-message-generation.md
+++ b/docs/commit-message-generation.md
@@ -37,13 +37,17 @@ Control which AI model is used for all generation features.
 |-------|-------------|
 | `gpt-4o` | OpenAI's most advanced general-purpose model, offering excellent code understanding |
 | `gpt-4o-mini` | Faster and more cost-effective version of GPT-4o |
+| `gpt-4.1` | Latest GPT-4 model with enhanced capabilities |
+| `gpt-5` | Next generation GPT model with larger context and improved capability |
+| `gpt-5-mini` | Next generation mini model with improved efficiency and capabilities |
 | `claude-3.5-sonnet` | Anthropic's model with excellent context understanding and reasoning |
+| `claude-sonnet-4` | Latest Anthropic model with enhanced capabilities |
 | `o1` | OpenAI's o1 model optimized for reasoning tasks |
 | `o1-mini` | Smaller, faster version of the o1 model |
 
 Consider your specific needs when selecting a model:
-- For highest quality output: `gpt-4o` or `claude-3.5-sonnet`
-- For faster response times: `gpt-4o-mini` or `o1-mini`
+- For highest quality output: `gpt-4o`, `gpt-4.1`, `gpt-5`, or `claude-3.5-sonnet`
+- For faster response times: `gpt-4o-mini`, `gpt-5-mini`, or `o1-mini`
 - For complex reasoning about code changes: `o1`
 
 ### Commit Style

--- a/docs/pr-review-assistance.md
+++ b/docs/pr-review-assistance.md
@@ -74,8 +74,8 @@ The `maxTokensPerGroup` setting controls how many files are processed together i
 ```
 
 Recommended values based on model:
-- **6000-8000**: For GPT-4o-mini or similar smaller models
-- **16000-32000**: For GPT-4o, GPT-4.1, Claude 3.5 Sonnet, Claude 4 Sonnet, or similar standard models
+- **6000-8000**: For GPT-4o-mini, GPT-5 Mini, or similar smaller models
+- **16000-32000**: For GPT-4o, GPT-4.1, GPT-5, Claude 3.5 Sonnet, Claude 4 Sonnet, or similar standard models
 - **Up to 64000**: For latest models with expanded context windows
 
 Increasing this value allows more files to be processed together, potentially improving the quality of the review by giving the model more context. However, it requires more capable models with larger context windows.

--- a/media/breaking-changes/breaking-changes-panel.js
+++ b/media/breaking-changes/breaking-changes-panel.js
@@ -83,7 +83,7 @@
       const [isLoading, setIsLoading] = React.useState(false);
       const [error, setError] = React.useState(null);
       const [result, setResult] = React.useState(null);
-      const [languageModel, setLanguageModel] = React.useState('gpt-4.1');
+  const [languageModel, setLanguageModel] = React.useState('gpt-5-mini');
       const [filterSeverity, setFilterSeverity] = React.useState('all');
       const [filterChangeType, setFilterChangeType] = React.useState('all');
       const [searchTerm, setSearchTerm] = React.useState('');

--- a/media/breaking-changes/breaking-changes-panel.js
+++ b/media/breaking-changes/breaking-changes-panel.js
@@ -94,6 +94,8 @@
         { id: 'gpt-4o', name: 'GPT-4o' },
         { id: 'gpt-4o-mini', name: 'GPT-4o-mini' },
         { id: 'gpt-4.1', name: 'GPT-4.1' },
+        { id: 'gpt-5', name: 'GPT-5' },
+        { id: 'gpt-5-mini', name: 'GPT-5 Mini' },
         { id: 'claude-3.5-sonnet', name: 'Claude 3.5 Sonnet' },
         { id: 'claude-sonnet-4', name: 'Claude 4 Sonnet' },
         { id: 'o1', name: 'o1' },

--- a/media/modelConfig.js
+++ b/media/modelConfig.js
@@ -6,6 +6,8 @@
         { id: 'gpt-4o', name: 'GPT-4o : Most capable model, best for complex understanding' },
         { id: 'gpt-4o-mini', name: 'GPT-4o-mini : Faster variant with slightly reduced capabilities' },
         { id: 'gpt-4.1', name: 'GPT-4.1 : Latest GPT-4 model with enhanced capabilities' },
+        { id: 'gpt-5', name: 'GPT-5 : Next generation GPT model with larger context and improved capability' },
+        { id: 'gpt-5-mini', name: 'GPT-5 Mini : Next generation mini model with improved efficiency and capabilities' },
         { id: 'claude-3.5-sonnet', name: "Claude 3.5 Sonnet : Anthropic's most capable model with advanced reasoning" },
         { id: 'claude-sonnet-4', name: 'Claude 4 Sonnet : Latest Anthropic model with enhanced capabilities' },
         { id: 'o1', name: 'o1 : OpenAI o1 model, highest reasoning capabilities' },

--- a/media/pr-description/prDescription.js
+++ b/media/pr-description/prDescription.js
@@ -7,7 +7,7 @@
       const [branches, setBranches] = React.useState([]);
       const [sourceBranch, setSourceBranch] = React.useState('');
       const [targetBranch, setTargetBranch] = React.useState('');
-      const [selectedModel, setSelectedModel] = React.useState('gpt-4.1');
+  const [selectedModel, setSelectedModel] = React.useState('gpt-5-mini');
       const [isLoading, setIsLoading] = React.useState(false);
       const [error, setError] = React.useState('');
       const [result, setResult] = React.useState(null);

--- a/media/sidebar.js
+++ b/media/sidebar.js
@@ -31,7 +31,7 @@
       const [branches, setBranches] = React.useState([]);
       const [sourceBranch, setSourceBranch] = React.useState('');
       const [targetBranch, setTargetBranch] = React.useState('');
-      const [selectedModel, setSelectedModel] = React.useState('gpt-4.1');
+  const [selectedModel, setSelectedModel] = React.useState('gpt-5-mini');
       const [isLoading, setIsLoading] = React.useState(false);
       const [error, setError] = React.useState('');
       const [result, setResult] = React.useState(null);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-plus-plus",
   "displayName": "Copilot++",
   "description": "Enhances GitHub Copilot capabilities with AI-powered development workflows.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publisher": "albaktiar",
   "engines": {
     "vscode": "^1.98.0"
@@ -124,6 +124,8 @@
             "gpt-4o",
             "gpt-4o-mini",
             "gpt-4.1",
+            "gpt-5",
+            "gpt-5-mini",
             "claude-3.5-sonnet",
             "claude-sonnet-4",
             "o1",
@@ -133,6 +135,8 @@
             "GPT-4o - Most capable model, best for complex understanding",
             "GPT-4o-mini - Faster variant with slightly reduced capabilities",
             "GPT-4.1 - Latest GPT-4 model with enhanced capabilities",
+            "GPT-5 - Next generation GPT model with larger context and improved capability",
+            "GPT-5 Mini - Next generation mini model with improved efficiency and capabilities",
             "Claude 3.5 Sonnet - Anthropic's most capable model with advanced reasoning",
             "Claude 4 Sonnet - Latest Anthropic model with enhanced capabilities",
             "o1 - OpenAI o1 model, highest reasoning capabilities",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
             "o1 - OpenAI o1 model, highest reasoning capabilities",
             "o1-mini - Smaller, faster OpenAI o1 model"
           ],
-          "default": "gpt-4.1",
+          "default": "gpt-5-mini",
           "description": "The language model to use for generating commit messages"
         },
         "copilotPlusPlus.defaultTargetBranch": {

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -49,7 +49,7 @@ export class ConfigService {
   public static getCommitMessageConfig(): CommitMessageConfig {
     const config = vscode.workspace.getConfiguration('copilotPlusPlus');
     return {
-      languageModel: config.get<string>('languageModel') || 'gpt-4.1',
+  languageModel: config.get<string>('languageModel') || 'gpt-5-mini',
       commitStyle: config.get<string>('commitStyle') || 'conventional',
       includeTicketNumber: config.get<boolean>('includeTicketNumber') ?? true,
       ticketPattern: config.get<string>('ticketPattern') || '(?:^|\\/)([A-Z]+-\\d+)(?:\\/|$|[-_])',
@@ -92,7 +92,7 @@ export class ConfigService {
    */
   public static getLanguageModelFamily(): string {
     const config = vscode.workspace.getConfiguration('copilotPlusPlus');
-    return config.get<string>('languageModel') || 'gpt-4.1';
+  return config.get<string>('languageModel') || 'gpt-5-mini';
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR introduces GPT-5 and GPT-5 Mini as selectable language models across the extension, updates documentation and webviews to expose the new options, and changes the default language model to `gpt-5-mini`. It also bumps the extension version to 0.0.17 and updates the changelog.

---

## Purpose

- Add GPT-5 (`gpt-5`) and GPT-5 Mini (`gpt-5-mini`) to the list of supported language models so users can choose next-generation models.
- Make `gpt-5-mini` the new default model in UI components and configuration fallbacks to provide an efficient, capable default experience.
- Keep documentation, changelog, and packaging metadata in sync with the model additions and default change.

---

## Approach

- Add entries for the two new models in model configuration files and webviews so they appear in model selectors.
- Update UI initial state in webview components (PR description, sidebar, breaking-changes panel) to default to `gpt-5-mini` instead of `gpt-4.1`.
- Update configuration service fallbacks so server-side or extension-side defaults match the UI default.
- Bump package version and add release notes to CHANGELOG and README.

---

## Technical Details

Key files changed and nature of changes:

- CHANGELOG.md
  - Added a new 0.0.17 release entry documenting the addition of GPT-5 and GPT-5 Mini and related UI/documentation updates.

- README.md
  - Documented GPT-5 and GPT-5 Mini in the supported models list and added release notes for 0.0.17.

- docs/*.md
  - docs/breaking-changes-analysis.md, docs/commit-message-generation.md, docs/pr-review-assistance.md
  - Updated docs to include `gpt-5` and `gpt-5-mini` in model recommendations and advice for context window sizing.

- media/modelConfig.js
  - Added the two new model entries with descriptive labels so they are selectable in webviews.

- media/pr-description/prDescription.js
  - Changed the initial selected model state from `gpt-4.1` to `gpt-5-mini` so the PR description webview defaults to the new model.

- media/sidebar.js
  - Changed the initial selected model state from `gpt-4.1` to `gpt-5-mini` for the sidebar webview.

- media/breaking-changes/breaking-changes-panel.js
  - Changed the initial languageModel state to `gpt-5-mini` and added `gpt-5` and `gpt-5-mini` to the selector list.

- src/services/configService.ts
  - Updated fallback/default returns for language model to use `gpt-5-mini` where the config value is absent.

- package.json
  - Bumped version to `0.0.17`.
  - Added `gpt-5` and `gpt-5-mini` to the allowed values and updated the default to `gpt-5-mini` and the human-readable option list.

Files changed summary (counts): 11 files changed; updates include additions to lists, default value changes, documentation updates, and a version bump.

---

## Commits (grouped)

- Features
  - cd55afd: feat(models): set default language model to gpt-5-mini — Switch default model in UI initial state so panels and sidebars initialize with `gpt-5-mini`.
  - 7780d09: feat(models): add GPT-5 and GPT-5 Mini; update README, docs, and changelog — Add new models, documentation, and changelog entry; update webviews and config lists.

- Other commits
  - A few intermediate/placeholder commits appear in the provided history but do not contain identifiable metadata in the diff summary. The primary functional changes are represented by the feature commits above.

---

## Testing / Validation

Recommended manual checks to validate the change:

1. UI defaults
   - Open the PR Description webview, Sidebar, and Breaking Changes panel in the extension and confirm the default selected model is `GPT-5 Mini` (shown as `gpt-5-mini`).
   - Open each model selector and confirm `GPT-5` and `GPT-5 Mini` appear in the list.

2. Configuration fallback
   - Remove any user-specified `copilotPlusPlus.languageModel` setting and confirm the extension falls back to `gpt-5-mini` via the behavior in `ConfigService`.

3. Documentation & packaging
   - Verify README, docs, and CHANGELOG include the new models and release notes.
   - Confirm package.json lists the new models and that the `default` property is `gpt-5-mini`.

4. Extension run
   - Run the extension locally (Debug in VS Code) and exercise features that call the language model selection (commit message generation, PR description generation, breaking changes analysis) to ensure no runtime errors occur due to the new model identifiers.

Optional automated tests (if present)
- Add or update unit tests around config fallback behavior and any functions that map model identifiers to metadata.

---

## Backwards compatibility and notes

- The change should be backwards compatible for users who explicitly configure a different model; if a user has `copilotPlusPlus.languageModel` set to a specific value it will continue to override the new default.
- If any integrations relied on `gpt-4.1` as an implicit default, they will now see `gpt-5-mini` unless explicitly configured.

---

If desired, follow-up PRs could add telemetry/usage metrics for the new models and surface model capabilities or pricing hints in the UI.